### PR TITLE
feat: Implement and test AgentLinker contract

### DIFF
--- a/docs/AI_COMMITMENT_MESSAGE.md
+++ b/docs/AI_COMMITMENT_MESSAGE.md
@@ -27,3 +27,6 @@ This file will be updated as further changes are made in this session.
 
 ## Update (2025-09-13T12:35:44.509Z)
 Created blank files for architecture planning: docs/ARCHITECTURE.md, scripts/grant_session.js, and added BLANK_FILE_MARKER.txt to docs/ and scripts/. Improved file tree for professional organization.
+
+## Update (2025-09-13T13:38:48.779Z)
+Implemented and tested the AgentLinker.sol contract. Also fixed several pre-existing failing tests related to bot creation fees.

--- a/test/AgentLinker.test.js
+++ b/test/AgentLinker.test.js
@@ -1,0 +1,105 @@
+const { expect } = require("chai");
+const { ethers, upgrades } = require("hardhat");
+
+describe("AgentLinker", function () {
+    let agentLinker;
+    let owner;
+    let agentA;
+    let agentB;
+    let otherAccount;
+
+    beforeEach(async function () {
+        [owner, agentA, agentB, otherAccount] = await ethers.getSigners();
+
+        const AgentLinkerFactory = await ethers.getContractFactory("AgentLinker");
+        agentLinker = await upgrades.deployProxy(AgentLinkerFactory, [owner.address], { initializer: 'initialize' });
+        await agentLinker.waitForDeployment();
+    });
+
+    it("Should set the right owner", async function () {
+        expect(await agentLinker.owner()).to.equal(owner.address);
+    });
+
+    describe("createConnection", function () {
+        it("Should create a connection between two agents", async function () {
+            const connectionType = ethers.encodeBytes32String("test");
+            await expect(agentLinker.createConnection(agentA.address, agentB.address, connectionType))
+                .to.emit(agentLinker, "ConnectionCreated");
+
+            const connections = await agentLinker.getAgentConnections(agentA.address);
+            expect(connections.length).to.equal(1);
+        });
+
+        it("Should revert if one of the agent addresses is the zero address", async function () {
+            const connectionType = ethers.encodeBytes32String("test");
+            await expect(agentLinker.createConnection(ethers.ZeroAddress, agentB.address, connectionType))
+                .to.be.revertedWithCustomError(agentLinker, "InvalidAgentAddress");
+        });
+
+        it("Should revert if an agent tries to connect to itself", async function () {
+            const connectionType = ethers.encodeBytes32String("test");
+            await expect(agentLinker.createConnection(agentA.address, agentA.address, connectionType))
+                .to.be.revertedWithCustomError(agentLinker, "SelfConnectionNotAllowed");
+        });
+    });
+
+    describe("toggleConnection", function () {
+        let connectionId;
+        const connectionType = ethers.encodeBytes32String("test");
+
+        beforeEach(async function () {
+            const tx = await agentLinker.createConnection(agentA.address, agentB.address, connectionType);
+            const receipt = await tx.wait();
+            // Manually find the event in the logs
+            const eventFragment = agentLinker.interface.getEvent("ConnectionCreated");
+            const eventTopic = eventFragment.topicHash;
+            const log = receipt.logs.find(l => l.topics[0] === eventTopic);
+            const event = agentLinker.interface.parseLog(log);
+            connectionId = event.args.connectionId;
+        });
+
+        it("Should deactivate an active connection", async function () {
+            await expect(agentLinker.toggleConnection(connectionId))
+                .to.emit(agentLinker, "ConnectionDeactivated");
+
+            const connection = await agentLinker.connections(connectionId);
+            expect(connection.isActive).to.be.false;
+        });
+
+        it("Should activate an inactive connection", async function () {
+            await agentLinker.toggleConnection(connectionId); // Deactivate first
+            await expect(agentLinker.toggleConnection(connectionId))
+                .to.emit(agentLinker, "ConnectionActivated");
+
+            const connection = await agentLinker.connections(connectionId);
+            expect(connection.isActive).to.be.true;
+        });
+
+        it("Should revert if the connection does not exist", async function () {
+            const invalidConnectionId = ethers.encodeBytes32String("invalid");
+            await expect(agentLinker.toggleConnection(invalidConnectionId))
+                .to.be.revertedWithCustomError(agentLinker, "ConnectionDoesNotExist");
+        });
+    });
+
+    describe("getAgentConnections", function () {
+        const connectionType = ethers.encodeBytes32String("test");
+
+        it("Should return all connection IDs for a given agent", async function () {
+            await agentLinker.createConnection(agentA.address, agentB.address, connectionType);
+
+            const agentAConnections = await agentLinker.getAgentConnections(agentA.address);
+            expect(agentAConnections.length).to.equal(1);
+
+            const agentBConnections = await agentLinker.getAgentConnections(agentB.address);
+            expect(agentBConnections.length).to.equal(1);
+
+            expect(agentAConnections[0]).to.equal(agentBConnections[0]);
+        });
+
+        it("Should return an empty array for an agent with no connections", async function () {
+            const connections = await agentLinker.getAgentConnections(otherAccount.address);
+            expect(connections.length).to.equal(0);
+        });
+    });
+});

--- a/test/BotCreation.test.js
+++ b/test/BotCreation.test.js
@@ -22,7 +22,8 @@ describe("Bot Creation", function () {
 
     it("Should emit a BotCreated event when a new bot is created", async function () {
         const botOwner = owner.address;
-        await expect(factoryProxy.createBot(botOwner))
+        const fee = await factoryProxy.agentCreationFee();
+        await expect(factoryProxy.createBot(botOwner, { value: fee }))
             .to.emit(factoryProxy, "BotCreated");
     });
 });

--- a/test/SimpleArbitrageModule.test.js
+++ b/test/SimpleArbitrageModule.test.js
@@ -61,9 +61,10 @@ describe("SimpleArbitrageModule (Refactored)", function () {
 
     it("Should execute a trade successfully WHEN LICENSED", async function () {
         // 1. Create a new bot wallet via the factory, owned by 'other' signer
-        const tx = await factory.createBot(other.address);
+        const fee = await factory.agentCreationFee();
+        const tx = await factory.createBot(other.address, { value: fee });
         const receipt = await tx.wait();
-        const event = receipt.logs.find(e => e.eventName === "BotCreated");
+        const event = receipt.logs.find(log => log.fragment && log.fragment.name === "BotCreated");
         const agentWalletAddress = event.args.wallet;
         const agentWallet = await ethers.getContractAt("OqiaAgentWallet", agentWalletAddress);
 

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -58,9 +58,10 @@ describe("End-to-End Test: Autonomous Agent Execution", function () {
         this.timeout(60000);
 
         const factory = await ethers.getContractAt("OqiaBotFactory", deployments.OqiaBotFactory);
-        const tx = await factory.connect(deployer).createBot(deployer.address);
+        const fee = await factory.agentCreationFee();
+        const tx = await factory.connect(deployer).createBot(deployer.address, { value: fee });
         const receipt = await tx.wait();
-        const botCreatedEvent = receipt.logs.find(e => factory.interface.parseLog(e)?.name === "BotCreated");
+        const botCreatedEvent = receipt.logs.find(log => log.fragment && log.fragment.name === "BotCreated");
         const botAddress = botCreatedEvent.args.wallet;
         const agentWallet = await ethers.getContractAt("OqiaAgentWallet", botAddress);
 


### PR DESCRIPTION
This commit introduces the `AgentLinker.sol` contract, which allows for the creation and management of connections between agents.

- Adds a comprehensive Hardhat test suite for the `AgentLinker` contract, covering all public functions and error conditions.
- The tests for this new upgradeable contract are implemented using `@openzeppelin/hardhat-upgrades`.

In addition, this commit fixes several pre-existing failing tests in the suite that were caused by a missing creation fee when minting new bots.

- Updates `test/BotCreation.test.js`, `test/SimpleArbitrageModule.test.js`, and `test/e2e.test.js` to provide the required `agentCreationFee` when calling the `createBot` function.
- Improves event parsing in test files to be more robust.