### PR TITLE
feat: Add comprehensive tests for OqiaBotFactory

### DIFF
--- a/contracts/mocks/ReentrancyAttacker.sol
+++ b/contracts/mocks/ReentrancyAttacker.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "../OqiaBotFactory.sol";
+
+contract ReentrancyAttacker {
+    OqiaBotFactory public factory;
+    address public attacker;
+    uint256 public tokenId;
+
+    constructor(address _factory) {
+        factory = OqiaBotFactory(_factory);
+        attacker = msg.sender;
+    }
+
+    function attack() external payable {
+        (bool success, ) = address(factory).call{value: msg.value}(
+            abi.encodeWithSignature("createBot(address)", address(this))
+        );
+        require(success, "Initial call failed");
+    }
+
+    receive() external payable {
+        // Reentrant call
+        if (address(factory).balance >= 0.001 ether) {
+            (bool success, ) = address(factory).call{value: 0.001 ether}(
+                abi.encodeWithSignature("createBot(address)", address(this))
+            );
+            require(success, "Reentrant call failed");
+        }
+    }
+}

--- a/docs/AI_COMMITMENT_MESSAGE.md
+++ b/docs/AI_COMMITMENT_MESSAGE.md
@@ -30,3 +30,6 @@ Created blank files for architecture planning: docs/ARCHITECTURE.md, scripts/gra
 
 ## Update (2025-09-13T13:38:48.779Z)
 Implemented and tested the AgentLinker.sol contract. Also fixed several pre-existing failing tests related to bot creation fees.
+
+## Update (2025-09-13T14:19:10.809Z)
+Improved test coverage for OqiaBotFactory.sol. Refactored existing tests, added comprehensive checks for createBot, tokenURI, admin functions, ERC-2981 royalties, and a reentrancy attack scenario. The test suite for the factory is now robust and covers all critical functionality.


### PR DESCRIPTION
This commit significantly improves the test coverage for the `OqiaBotFactory.sol` contract.

The following improvements have been made:
- Refactored and cleaned up the existing test file.
- Added comprehensive tests for the `createBot` function, covering success cases, event emissions, and error handling.
- Added tests for the token URI functionality, including default and custom URIs.
- Added tests for the admin functions `setAgentCreationFee` and `setRoyaltyInfo`.
- Added tests for ERC-2981 royalty compliance.
- Added a reentrancy attack test to ensure the `nonReentrant` modifier on `createBot` is effective.